### PR TITLE
Fix Result Report Race Condition in Pipe-based Context Switching Test

### DIFF
--- a/UnixBench/src/context1.c
+++ b/UnixBench/src/context1.c
@@ -94,38 +94,33 @@ char	*argv[];
 		}
 	}
 	else { /* child process */
-		unsigned long iter1;
-
-		iter1 = 0;
 		/* slave, read p1 & write p2 */
 		close(p1[1]); close(p2[0]);
 		while (1) {
 			if ((ret = read(p1[0], (char *)&check, sizeof(check))) != sizeof(check)) {
 				if ((ret == 0)) { /* end-of-stream */
 					alarm(0);
-					iter = iter1;
 					report(); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
 					perror("slave read failed");
 				exit(1);
 			}
-			if (check != iter1) {
+			if (check != iter) {
 				fprintf(stderr, "Slave sync error: expect %lu, got %lu\n",
 					iter, check);
 				exit(2);
 			}
-			if ((ret = write(p2[1], (char *)&iter1, sizeof(iter1))) != sizeof(check)) {
+			if ((ret = write(p2[1], (char *)&iter, sizeof(iter))) != sizeof(check)) {
 				if ((ret == -1) && (errno == EPIPE)) {
 					alarm(0);
-					iter = iter1;
 					report(); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
 					perror("slave write failed");
 				exit(1);
 			}
-			iter1++;
+			iter++;
 		}
 	}
 }

--- a/UnixBench/src/context1.c
+++ b/UnixBench/src/context1.c
@@ -103,6 +103,7 @@ char	*argv[];
 			if ((ret = read(p1[0], (char *)&check, sizeof(check))) != sizeof(check)) {
 				if ((ret == 0)) { /* end-of-stream */
 					alarm(0);
+					iter = iter1;
 					report(); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
@@ -117,6 +118,7 @@ char	*argv[];
 			if ((ret = write(p2[1], (char *)&iter1, sizeof(iter1))) != sizeof(check)) {
 				if ((ret == -1) && (errno == EPIPE)) {
 					alarm(0);
+					iter = iter1;
 					report(); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))


### PR DESCRIPTION
Ensure all `report()` calls yield correct information.

The `report()` call prints the value of `iter`.  This is still **zero(0)** when the process forks.

I tested both removing the call in the child fork and never had a test where the result didn't get written.  I also tested with setting `iter` in the child to `iter1`, the iteration variable for the child process, just before the call to `report()`.  This resulted in two lines written every time in my testing.

I'm submitting the code that will report from both forks just in case there is a condition where the parent will get killed before reporting the result.  I don't think this will happen, but the test runner handles the case of receiving two lines correctly and without complaint.