### PR TITLE
Added change directories and filename via Environment variables.

### DIFF
--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -5,6 +5,7 @@ use strict;
 use POSIX qw(strftime);
 use Time::HiRes;
 use IO::Handle;
+use File::Path;
 use FindBin;
 
 
@@ -569,17 +570,33 @@ sub getCmdOutput {
 sub getDir {
     my ( $var, $def ) = @_;
 
+    # If Environment variables(e.g. UB_RESULTDIR) is unset, use default value.
     my $val = $ENV{$var} || $def;
 
-    # Canonicalise the value.
-    my $wd;
-    chomp($wd = `pwd`);
-    chdir($val);
-    chomp($val = `pwd`);
-    chdir($wd);
+    # Only "execl.c" test needs the Environment variable(UB_BINDIR).
     $ENV{$var} = $val;
 
-    $val;
+    return $val;
+}
+
+# Create direcotry(0755) if not exists.
+sub createDirrectoriesIfNotExists {
+    foreach my $path (@_) {
+        my $isDirectoryNotExists = ! -d $path;
+        if ( $isDirectoryNotExists ) {
+            mkpath($path, {chmod => 0755});
+        }
+    }
+}
+
+# Show use directories.
+sub printUsingDirectories {
+    printf "------------------------------------------------------------------------------\n";
+    printf "   Use directories for:\n";
+    printf "      * File I/O tests (named fs***) = ${TMPDIR}\n";
+    printf "      * Results                      = ${RESULTDIR}\n";
+    printf "------------------------------------------------------------------------------\n";
+    printf "\n";
 }
 
 
@@ -588,11 +605,18 @@ sub getDir {
 sub logFile {
     my ( $sysInfo ) = @_;
 
-    my $count = 1;
+    # If supplied output file name via Environment variable(UB_OUTPUT_FILE_NAME), then use it.
+    #   * If exists same file, it will be overwrite completly.
+    my $output_file_name_supplied_by_environment = $ENV{"UB_OUTPUT_FILE_NAME"};
+    if ( defined($output_file_name_supplied_by_environment) && $output_file_name_supplied_by_environment ne "" ) {
+        return ${RESULTDIR} . "/" . $output_file_name_supplied_by_environment;
+    }
+
 
     # Use the date in the base file name.
     my $ymd = strftime "%Y-%m-%d", localtime;
 
+    my $count = 1;
     while (1) {
         my $log = sprintf "%s/%s-%s-%02d",
                         ${RESULTDIR}, $sysInfo->{'name'}, $ymd, $count;
@@ -1830,6 +1854,10 @@ sub main {
         $tests = $index;
     }
 
+    # Create directories.    
+    my @creatingDirectories = ( ${TMPDIR}, ${RESULTDIR} );
+    createDirrectoriesIfNotExists(@creatingDirectories);
+
     preChecks();
     my $systemInfo = getSystemInfo();
 
@@ -1845,6 +1873,11 @@ sub main {
 
     # Display the program banner.
     system("cat \"${BINDIR}/unixbench.logo\"");
+
+    # Show output output directories, if not in quiet mode.
+    if ($verbose > 0) {
+        printUsingDirectories();
+    }
 
     if ($verbose > 1) {
         printf "\n", join(", ", @$tests);

--- a/UnixBench/USAGE
+++ b/UnixBench/USAGE
@@ -65,6 +65,11 @@ so that randomly-churning background processes don't randomise the results
 too much.  This is particularly true for the graphics tests.
 
 
+If you need to change the directories, use "Environment variables" about below.
+
+  * "UB_RESULTDIR"        : Output destination path(absolute) of the result files.
+  * "UB_TMPDIR"           : Directory path(absolute) used for file I/O tests(named fs****).
+  * "UB_OUTPUT_FILE_NAME" : Output file name. If exists same file, it will be overwrite completly.
 ============================================================================
 
 Tests


### PR DESCRIPTION
UnixBench was trying support to change directories via Environment variables, I think.
But could not use it because the code was not correctly.
Therefore, I enable it.
And, also added support to change filename.

This change does not affect the benchmark score.

------------------------------
usage:
### 1. Change output directory
```bash
export UB_RESULTDIR=/tmp/benchmark_result/
./Run
```

### 2. Change benchmarking directory of file based benchmark (named as "fs****")
```bash
export UB_TMPDIR=/tmp/working_directory/
./Run
```

### 3. Change output file name
```bash
export UB_OUTPUT_FILE_NAME=test_benchmark_result
./Run
```


-------------------------------

With all three options, result is below.


```bash
[root@Palladium v5.1.3_environment_changes]# ./Run -i 1 -c 1 fstime

# (something make log skiped)

   #    #  #    #  #  #    #          #####   ######  #    #   ####   #    #
   #    #  ##   #  #   #  #           #    #  #       ##   #  #    #  #    #
   #    #  # #  #  #    ##            #####   #####   # #  #  #       ######
   #    #  #  # #  #    ##            #    #  #       #  # #  #       #    #
   #    #  #   ##  #   #  #           #    #  #       #   ##  #    #  #    #
    ####   #    #  #  #    #          #####   ######  #    #   ####   #    #

   Version 5.1.3                      Based on the Byte Magazine Unix Benchmark

   Multi-CPU version                  Version 5 revisions by Ian Smith,
                                      Sunnyvale, CA, USA
   January 13, 2011                   johantheghost at yahoo period com

------------------------------------------------------------------------------
   Use directories for:
      * File I/O tests (named fs***) = /tmp/working_directory/
      * Results                      = /tmp/benchmark_result/
------------------------------------------------------------------------------

# test results...
```

On benchmarking:
```bash
[root@Palladium results]# ls -al /tmp/working_directory/
合計 12
drwxr-xr-x  2 root root 4096  1月 12 13:08 2018 .
drwxrwxrwt. 7 root root 4096  1月 12 13:06 2018 ..
-rw-------  1 root root    0  1月 12 13:08 2018 dummy0
-rw-------  1 root root    0  1月 12 13:08 2018 dummy1
-rwxr-xr-x  1 root root   14  1月 12 13:08 2018 kill_run
```

Result: 
```bash
[root@Palladium results]# ls -al /tmp/benchmark_result/
合計 20
drwxr-xr-x  2 root root 4096  1月 12 13:06 2018 .
drwxrwxrwt. 7 root root 4096  1月 12 13:06 2018 ..
-rw-r--r--  1 root root 1037  1月 12 13:09 2018 test_benchmark_result
-rw-r--r--  1 root root 3258  1月 12 13:09 2018 test_benchmark_result.html
-rw-r--r--  1 root root 1286  1月 12 13:09 2018 test_benchmark_result.log
```