### PR TITLE
Added csv support(score only) by Environment variable.

### DIFF
--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -1561,6 +1561,48 @@ sub summarizeRun {
 }
 
 
+# Write CSV Headers.
+#   e.g.: "Concurrency,Dhrystone 2 using register variables,Double-Precision Whetstone"
+#       
+sub summarizeRunCsvHeader {
+    my ( $results, $reportFd ) = @_;
+
+    # First col is for Concurrency value.
+    printf $reportFd "Concurrency";
+
+    # Write CSV Headers of test.
+    foreach my $bench (@{$results->{'list'}}) {
+        my $bresult = $results->{$bench};
+        printf $reportFd ",%s", $bresult->{'msg'};
+    }
+    printf $reportFd "\n";
+}
+
+# Write CSV data rows per concurrency as "./Run -c 1 -c 2".
+#   e.g.: 1,33526940.9,3623.9
+#         2,30386997.8,3678.8
+#         4,31439797.3,3781.4
+#         8,32872262.9,3826.2
+sub summarizeRunCsvRows {
+    my ( $results, $reportFd) = @_;
+
+    # Write concurrency value.
+    printf $reportFd "%d", $results->{'copies'};
+    
+    # Write test results.
+    my $isFirstColumn = 1;
+    foreach my $bench (@{$results->{'list'}}) {
+        my $bresult = $results->{$bench};
+
+        printf $reportFd ",%.1f", $bresult->{'score'};
+        $isFirstColumn = 0;
+    }
+
+    printf $reportFd "\n";
+}
+
+
+
 ############################################################################
 # HTML REPORTS
 ############################################################################
@@ -1854,13 +1896,26 @@ sub main {
     # Generate unique file names for the report and log file.
     my $reportFile = logFile($systemInfo);
     my $reportHtml = $reportFile . ".html";
+    my $reportCsv = $reportFile . ".csv";
     my $logFile = $reportFile . ".log";
 
+    # If defined "UB_OUTPUT_CSV" on Environment, output csv file.
+    my $ubOutputCsv = $ENV{"UB_OUTPUT_CSV"};
+    my $isOutputFormatCsv = defined($ubOutputCsv) && $ubOutputCsv eq "true";
+    # If write CSV, header needs only once.
+    my $is_csv_header_written = 0;
+    
     # Open the log file for writing.
     open(my $reportFd, ">", $reportFile) ||
                             die("Run: can't write to $reportFile\n");
     open(my $reportFd2, ">", $reportHtml) ||
                             die("Run: can't write to $reportHtml\n");
+    my $reportFd_Csv;
+    if ($isOutputFormatCsv) {
+        open($reportFd_Csv, ">", $reportCsv) ||
+                            die("Run: can't write to $reportCsv\n");
+    }
+
     printf $reportFd "   BYTE UNIX Benchmarks (Version %s)\n\n", $version;
     runHeaderHtml($systemInfo, $reportFd2);
 
@@ -1879,6 +1934,14 @@ sub main {
 
         summarizeRun($systemInfo, $results, $verbose, $reportFd);
         summarizeRunHtml($systemInfo, $results, $verbose, $reportFd2);
+
+        if ($isOutputFormatCsv) {
+            if ( $is_csv_header_written == 0 ) {
+                summarizeRunCsvHeader($results, $reportFd_Csv);
+                $is_csv_header_written = 1;
+            }
+            summarizeRunCsvRows($results, $reportFd_Csv);
+        }
     }
 
     runFooterHtml($reportFd2);
@@ -1886,6 +1949,9 @@ sub main {
     # Finish the report.
     close($reportFd);
     close($reportFd2);
+    if ($isOutputFormatCsv) {
+        close($reportFd_Csv);
+    }
 
     # Display the report, if not in quiet mode.
     if ($verbose > 0) {

--- a/UnixBench/USAGE
+++ b/UnixBench/USAGE
@@ -65,6 +65,8 @@ so that randomly-churning background processes don't randomise the results
 too much.  This is particularly true for the graphics tests.
 
 
+If you need to change the directories, use "Environment variables" about below.
+  * "UB_OUTPUT_CSV"       : If set "true", output results(score only) to .csv.
 ============================================================================
 
 Tests


### PR DESCRIPTION
_I deleted Branch by mistake, so I will make a pull request again. Sorry!_

------------------------------

UnixBench outputs benchmark score as console, file, and HTML.

With such an output method, it is difficult to process when comparing the results obtained in multiple environments.
Therefore, I made it possible to output the result to CSV.

And this change does not affect the benchmark score.

------------------------------

UnixBench was trying support to change directories via Environment variables, I think.
So I decide to use Environment variable "UB_OUTPUT_CSV".

This option will output csv file to "results" directory.
If benchmark result is named `Banana-2018-01-12-01`, then csv file name is `Banana-2018-01-12-01.csv`.

usage:
```bash
export UB_OUTPUT_CSV=true
./Run -c 1 -c 2 -c 3 int double
```
output example:
```csv
Concurrency,Arithmetic Test (double),Arithmetic Test (int)
1,504156875.4,493839802.2
2,492484439.5,495202784.3
3,517763703.2,520804801.4
```