### PR TITLE
use getppid instead of getpid

### DIFF
--- a/UnixBench/src/syscall.c
+++ b/UnixBench/src/syscall.c
@@ -65,7 +65,7 @@ char	*argv[];
         case 'm':
 	   while (1) {
 		close(dup(0));
-		getpid();
+		getppid();
 		getuid();
 		umask(022);
 		iter++;
@@ -79,7 +79,7 @@ char	*argv[];
            /* NOTREACHED */
         case 'g':
            while (1) {
-                getpid();
+                getppid();
                 iter++;
            }
            /* NOTREACHED */


### PR DESCRIPTION
according to http://man7.org/linux/man-pages/man2/getpid.2.html
       
       From glibc version 2.3.4 up to and including version 2.24, the glibc
       wrapper function for getpid() cached PIDs, with the goal of avoiding
       additional system calls when a process calls getpid() repeatedly.

the getpid(2) will cache the result in some glibc version which will cause the unfair score result