### PR TITLE
A little trick to make Run recongnize the correct CPU cores on ARM machine

### DIFF
--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -713,7 +713,7 @@ sub getCpuInfo {
                 my $model = $val;
                 $model =~ s/  +/ /g;
                 $cpus->[$cpu]{'model'} = $model;
-            } elsif ($field eq "bogomips") {
+            } elsif ($field eq "bogomips" or $field eq "BogoMIPS") {
                 $cpus->[$cpu]{'bogo'} = $val;
             } elsif ($field eq "flags") {
                 $cpus->[$cpu]{'flags'} = processCpuFlags($val);


### PR DESCRIPTION
A little trick to make Run recongnize the correct CPU cores on ARM
machine, and then unixbench will run 1 threads and then multi-threads
which is the correct process.
Solve the Problem in issue :
https://github.com/kdlucas/byte-unixbench/issues/60