### PR TITLE
title[18] -> title[22]

### DIFF
--- a/UnixBench/src/whets.c
+++ b/UnixBench/src/whets.c
@@ -794,7 +794,7 @@ char	*argv[];
       }
 
 
-    void pout(char title[18], float ops, int type, SPDP checknum,
+    void pout(char title[22], float ops, int type, SPDP checknum,
 	      SPDP time, int calibrate, int section)
       {
 	SPDP mops,mflops;


### PR DESCRIPTION
compile warning:

```c
src/whets.c:797:20: warning: argument 1 of type ‘char[18]’ with mismatched bound [-Warray-parameter=]
  797 |     void pout(char title[18], float ops, int type, SPDP checknum,
      |               ~~~~~^~~~~~~~~
src/whets.c:315:17: note: previously declared as ‘char[22]’
  315 |  void pout(char title[22], float ops, int type, SPDP checknum,
      |            ~~~~~^~~~~~~~~
```

gcc version: `gcc (GCC) 11.2.1 20220127 (Red Hat 11.2.1-9)`