### PR TITLE
Use built-in arithmetic expansion feature to replace external expr to trigger tst.sh in parallel ASAP

### DIFF
--- a/UnixBench/pgms/multi.sh
+++ b/UnixBench/pgms/multi.sh
@@ -17,7 +17,7 @@ ID="@(#)multi.sh:3.4 -- 5/15/91 19:30:24";
 instance=1
 while [ $instance -le $1 ]; do
 	/bin/sh "$UB_BINDIR/tst.sh" &
-	instance=`expr $instance + 1`
+	instance=$(($instance + 1))
 done
 wait
 


### PR DESCRIPTION
 With the parallel/copy number grows, the cost percentage of `expr $instance + 1` will increase exponentially due to the contention, this will impact the real workload tst.sh trigger speed in the `while` section.  