### PR TITLE
fstime.c - Seperate r/w files for each parallel

### DIFF
--- a/UnixBench/src/fstime.c
+++ b/UnixBench/src/fstime.c
@@ -43,17 +43,13 @@ char SCCSid[] = "@(#) @(#)fstime.c:3.5 -- 5/15/91 19:30:19";
 #define SECONDS 10
 
 #define MAX_BUFSIZE 8192
-#define MAX_PATH 4096
 
 /* This must be set to the smallest BUFSIZE or 1024, whichever is smaller */
 #define COUNTSIZE 256
 #define HALFCOUNT (COUNTSIZE/2)         /* Half of COUNTSIZE */
 
-#define FNAME0  "dummy0"
-#define FNAME1  "dummy1"
-
-char file_f[MAX_PATH];
-char file_g[MAX_PATH];
+char FNAME0[] = "dummy0-XXXXXXXXXX";
+char FNAME1[] = "dummy1-XXXXXXXXXX";
 
 int w_test(int timeSecs);
 int r_test(int timeSecs);
@@ -175,26 +171,26 @@ char    *argv[];
     */
 
     int pid = getpid();
-    snprintf(file_f, MAX_PATH, "%s-%d", FNAME0, pid);
-    snprintf(file_g, MAX_PATH, "%s-%d", FNAME1, pid);
+    snprintf(FNAME0 + sizeof("dummy0"), sizeof(FNAME0) - sizeof("dummy0"), "%d", pid);
+    snprintf(FNAME1 + sizeof("dummy1"), sizeof(FNAME1) - sizeof("dummy1"), "%d", pid);
 
-    if((f = creat(file_f, 0600)) == -1) {
+    if((f = creat(FNAME0, 0600)) == -1) {
             perror("fstime: creat");
             exit(1);
     }
     close(f);
 
-    if((g = creat(file_g, 0600)) == -1) {
+    if((g = creat(FNAME1, 0600)) == -1) {
             perror("fstime: creat");
             exit(1);
     }
     close(g);
 
-    if( (f = open(file_f, 2)) == -1) {
+    if( (f = open(FNAME0, 2)) == -1) {
             perror("fstime: open");
             exit(1);
     }
-    if( ( g = open(file_g, 2)) == -1 ) {
+    if( ( g = open(FNAME1, 2)) == -1 ) {
             perror("fstime: open");
             exit(1);
     }
@@ -469,6 +465,6 @@ void stop_count(void)
 
 void clean_up(void)
 {
-        unlink(file_f);
-        unlink(file_g);
+        unlink(FNAME0);
+        unlink(FNAME1);
 }

--- a/UnixBench/src/fstime.c
+++ b/UnixBench/src/fstime.c
@@ -43,6 +43,7 @@ char SCCSid[] = "@(#) @(#)fstime.c:3.5 -- 5/15/91 19:30:19";
 #define SECONDS 10
 
 #define MAX_BUFSIZE 8192
+#define MAX_PATH 4096
 
 /* This must be set to the smallest BUFSIZE or 1024, whichever is smaller */
 #define COUNTSIZE 256
@@ -50,6 +51,9 @@ char SCCSid[] = "@(#) @(#)fstime.c:3.5 -- 5/15/91 19:30:19";
 
 #define FNAME0  "dummy0"
 #define FNAME1  "dummy1"
+
+char file_f[MAX_PATH];
+char file_g[MAX_PATH];
 
 int w_test(int timeSecs);
 int r_test(int timeSecs);
@@ -170,23 +174,27 @@ char    *argv[];
     }
     */
 
-    if((f = creat(FNAME0, 0600)) == -1) {
+    int pid = getpid();
+    snprintf(file_f, MAX_PATH, "%s-%d", FNAME0, pid);
+    snprintf(file_g, MAX_PATH, "%s-%d", FNAME1, pid);
+
+    if((f = creat(file_f, 0600)) == -1) {
             perror("fstime: creat");
             exit(1);
     }
     close(f);
 
-    if((g = creat(FNAME1, 0600)) == -1) {
+    if((g = creat(file_g, 0600)) == -1) {
             perror("fstime: creat");
             exit(1);
     }
     close(g);
 
-    if( (f = open(FNAME0, 2)) == -1) {
+    if( (f = open(file_f, 2)) == -1) {
             perror("fstime: open");
             exit(1);
     }
-    if( ( g = open(FNAME1, 2)) == -1 ) {
+    if( ( g = open(file_g, 2)) == -1 ) {
             perror("fstime: open");
             exit(1);
     }
@@ -461,6 +469,6 @@ void stop_count(void)
 
 void clean_up(void)
 {
-        unlink(FNAME0);
-        unlink(FNAME1);
+        unlink(file_f);
+        unlink(file_g);
 }


### PR DESCRIPTION
Existing workload is using 1 read file and 1 write file for file read/write/copy test. In multi-parallel scenario, it leads to high file lock contention, while read/write/copy is not stressed.

This change seperates r/w files for each parallel to satisfy the multi-parallel test purpose.