### PR TITLE
Optionally expand the size of sort.src for tst.sh shell workload

### DIFF
--- a/UnixBench/USAGE
+++ b/UnixBench/USAGE
@@ -107,7 +107,13 @@ The following individual tests are available:
     fsdisk           File Copy 4096 bufsize 8000 maxblocks
     shell1           Shell Scripts (1 concurrent) (runs "looper 60 multi.sh 1")
     shell8           Shell Scripts (8 concurrent) (runs "looper 60 multi.sh 8")
-    shell16          Shell Scripts (8 concurrent) (runs "looper 60 multi.sh 16")
+    shell16          Shell Scripts (16 concurrent)(runs "looper 60 multi.sh 16")
+                       Environment variable MULTI_SH_WORK_FACTOR (default 1)
+                       can be set to multiply the size of test input data (~8k)
+                       Note: changing MULTI_SH_WORK_FACTOR modifies the test.
+                       However, modifying the user/kernel workload balance may
+                       be useful for comparison with other systems on which the
+                       benchmark was run using the same MULTI_SH_WORK_FACTOR.
 
   2d:
     2d-rects         2D graphics: rectangles

--- a/UnixBench/pgms/multi.sh
+++ b/UnixBench/pgms/multi.sh
@@ -16,10 +16,11 @@
 ID="@(#)multi.sh:3.4 -- 5/15/91 19:30:24";
 instance=1
 sort_src=sort.src
-times_of_sort_src=${TIMES_OF_SORT_SRC:-1}
-if [ $times_of_sort_src -gt 1 ]; then
-	for i in $(seq $times_of_sort_src); do combine_sort_src="$combine_sort_src $sort_src"; done
-	cat $combine_sort_src > sort.src-alt.$$
+work_factor=${MULTI_SH_WORK_FACTOR:-1}
+if [ $work_factor -gt 1 ]; then
+	inputs=
+	for i in $(seq $work_factor); do inputs="$inputs $sort_src"; done
+	cat $inputs > sort.src-alt.$$
 	sort_src=sort.src-alt.$$
 fi
 
@@ -29,7 +30,6 @@ while [ $instance -le $1 ]; do
 done
 wait
 
-if [ $times_of_sort_src -gt 1 ]; then
+if [ $work_factor -gt 1 ]; then
 	rm $sort_src
 fi
-

--- a/UnixBench/pgms/multi.sh
+++ b/UnixBench/pgms/multi.sh
@@ -15,8 +15,9 @@
 ###############################################################################
 ID="@(#)multi.sh:3.4 -- 5/15/91 19:30:24";
 instance=1
+times_of_sort_src=20
 while [ $instance -le $1 ]; do
-	/bin/sh "$UB_BINDIR/tst.sh" 20 &
+	/bin/sh "$UB_BINDIR/tst.sh" $times_of_sort_src &
 	instance=$(($instance + 1))
 done
 wait

--- a/UnixBench/pgms/multi.sh
+++ b/UnixBench/pgms/multi.sh
@@ -16,7 +16,7 @@
 ID="@(#)multi.sh:3.4 -- 5/15/91 19:30:24";
 instance=1
 while [ $instance -le $1 ]; do
-	/bin/sh "$UB_BINDIR/tst.sh" &
+	/bin/sh "$UB_BINDIR/tst.sh" 20 &
 	instance=$(($instance + 1))
 done
 wait

--- a/UnixBench/pgms/multi.sh
+++ b/UnixBench/pgms/multi.sh
@@ -18,7 +18,7 @@ instance=1
 sort_src=sort.src
 times_of_sort_src=${TIMES_OF_SORT_SRC:-1}
 if [ $times_of_sort_src -gt 1 ]; then
-	for i in $(seq $times_of_sort_src); do combine_sort_src+=" $sort_src"; done
+	for i in $(seq $times_of_sort_src); do combine_sort_src="$combine_sort_src $sort_src"; done
 	cat $combine_sort_src > sort.src-alt.$$
 	sort_src=sort.src-alt.$$
 fi

--- a/UnixBench/pgms/multi.sh
+++ b/UnixBench/pgms/multi.sh
@@ -15,10 +15,21 @@
 ###############################################################################
 ID="@(#)multi.sh:3.4 -- 5/15/91 19:30:24";
 instance=1
-times_of_sort_src=20
+sort_src=sort.src
+times_of_sort_src=${TIMES_OF_SORT_SRC:-1}
+if [ $times_of_sort_src -gt 1 ]; then
+	for i in $(seq $times_of_sort_src); do combine_sort_src+=" $sort_src"; done
+	cat $combine_sort_src > sort.src-alt.$$
+	sort_src=sort.src-alt.$$
+fi
+
 while [ $instance -le $1 ]; do
-	/bin/sh "$UB_BINDIR/tst.sh" $times_of_sort_src &
+	/bin/sh "$UB_BINDIR/tst.sh" $sort_src &
 	instance=$(($instance + 1))
 done
 wait
+
+if [ $times_of_sort_src -gt 1 ]; then
+	rm $sort_src
+fi
 

--- a/UnixBench/pgms/tst.sh
+++ b/UnixBench/pgms/tst.sh
@@ -14,8 +14,7 @@
 #
 ###############################################################################
 ID="@(#)tst.sh:3.4 -- 5/15/91 19:30:24";
-sort_src_content=$(cat sort.src)
-printf "$sort_src_content%.0s\n" $(seq $1) | sort > sort.$$
+sort > sort.$$ < $1
 od sort.$$ | sort -n -k 1 > od.$$
 grep the sort.$$ | tee grep.$$ | wc > wc.$$
 rm sort.$$ grep.$$ od.$$ wc.$$

--- a/UnixBench/pgms/tst.sh
+++ b/UnixBench/pgms/tst.sh
@@ -14,7 +14,8 @@
 #
 ###############################################################################
 ID="@(#)tst.sh:3.4 -- 5/15/91 19:30:24";
-sort >sort.$$ <sort.src
+sort_src_content=$(cat sort.src)
+printf "$sort_src_content%.0s\n" $(seq $1) | sort > sort.src.$$
 od sort.$$ | sort -n -k 1 > od.$$
 grep the sort.$$ | tee grep.$$ | wc > wc.$$
 rm sort.$$ grep.$$ od.$$ wc.$$

--- a/UnixBench/pgms/tst.sh
+++ b/UnixBench/pgms/tst.sh
@@ -15,7 +15,7 @@
 ###############################################################################
 ID="@(#)tst.sh:3.4 -- 5/15/91 19:30:24";
 sort_src_content=$(cat sort.src)
-printf "$sort_src_content%.0s\n" $(seq $1) | sort > sort.src.$$
+printf "$sort_src_content%.0s\n" $(seq $1) | sort > sort.$$
 od sort.$$ | sort -n -k 1 > od.$$
 grep the sort.$$ | tee grep.$$ | wc > wc.$$
 rm sort.$$ grep.$$ od.$$ wc.$$


### PR DESCRIPTION
The data file named sort.src used in the Shell Scripts test cases inherited for more than a decade, where a balanced time distribution between the transformation of the data file and the creation of process became imbalanced in a system with dozens of cores nowadays. 
Would it be meaningful to enlarge the sort.src file to obey the original designate goal of the Shell Script tests, make them be more scalable on a modern system with many cores? 
Looking forward to hear your advice. 