### PR TITLE
Add riscv64 support

### DIFF
--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -33,6 +33,7 @@
 #                    01/13/11 added support for parallel compilation
 #                    01/07/16 [refer to version control commit messages and
 #                              cease using two-digit years in date formats]
+#                    04/11/23 added support for riscv64 
 ##############################################################################
 
 ##############################################################################
@@ -92,8 +93,8 @@ else
   ARCH := $(shell uname -m)
   ifeq ($(OSNAME),Linux)
     # Not all CPU architectures support "-march" or "-march=native".
-    #   - Supported    : x86, x86_64, ARM, AARCH64, etc..
-    #   - Not Supported: RISC-V, IBM Power, etc...
+    #   - Supported    : x86, x86_64, ARM, AARCH64, riscv64, etc..
+    #   - Not Supported: IBM Power, etc...
     ifneq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
 	#Add riscv64 support
 	ifeq ($(ARCH),riscv64)

--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -97,7 +97,7 @@ else
     ifneq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
 	#Add riscv64 support
 	ifeq ($(ARCH),riscv64)
-    	  OPTON += -march=rv64g
+    	  OPTON += -march=rv64g -mabi=lp64d
 	else
           OPTON += -march=native -mtune=native
 	endif

--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -89,13 +89,18 @@ else
 
   ## OS detection.  Comment out if gmake syntax not supported by other 'make'. 
   OSNAME:=$(shell uname -s)
-  ARCH := $(shell uname -p)
+  ARCH := $(shell uname -m)
   ifeq ($(OSNAME),Linux)
     # Not all CPU architectures support "-march" or "-march=native".
     #   - Supported    : x86, x86_64, ARM, AARCH64, etc..
     #   - Not Supported: RISC-V, IBM Power, etc...
     ifneq ($(ARCH),$(filter $(ARCH),ppc64 ppc64le))
-        OPTON += -march=native -mtune=native
+	#Add riscv64 support
+	ifeq ($(ARCH),riscv64)
+    	  OPTON += -march=rv64g
+	else
+          OPTON += -march=native -mtune=native
+	endif
     else
         OPTON += -mcpu=native -mtune=native
     endif


### PR DESCRIPTION
 #75 solved
GCC for riscv64 currently support -march,-mabi,-mcpu ,-mtune,  -march=riscv64g can be used  for almost all the riscv64 machines. I think the latter three flags should be omitted for capacities reason.

The modified source code are tested on x86(wsl2 Ubuntu20.04), aarch64(NanoPC-T4), riscv64 dev board(Nezha D1 and Sifive Unmatched) and riscv64 qemu environment.

`ARCH := $(shell uname -p)`
was modified to
`ARCH := $(shell uname -m)`

I'm not sure if this modification would have negative effect.

**This PR can not be applied to riscv32 platform.**