### PR TITLE
Add new tests using named pipe tests

### DIFF
--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -137,7 +137,7 @@ TMPDIR = ./tmp
 INCLDIR = /usr/include
 LIBDIR = /lib
 SCRIPTS = unixbench.logo multi.sh tst.sh index.base
-SOURCES = arith.c big.c context1.c \
+SOURCES = arith.c big.c context1.c context2.c \
 	dummy.c execl.c \
 	fstime.c hanoi.c \
 	pipe.c spawn.c \
@@ -159,7 +159,7 @@ BINS = $(PROGDIR)/arithoh $(PROGDIR)/register $(PROGDIR)/short \
 	$(PROGDIR)/pipe $(PROGDIR)/spawn $(PROGDIR)/execl \
 	$(PROGDIR)/dhry2 $(PROGDIR)/dhry2reg  $(PROGDIR)/looper \
 	$(PROGDIR)/fstime $(PROGDIR)/whetstone-double $(PROGDIR)/named_pipe \
-	$(GRAPHIC_BINS)
+	$(PROGDIR)/context2 $(GRAPHIC_BINS)
 ## These compile only on some platforms...
 # $(PROGDIR)/poll $(PROGDIR)/poll2 $(PROGDIR)/select
 
@@ -281,6 +281,8 @@ $(PROGDIR)/fstime: $(SRCDIR)/fstime.c
 $(PROGDIR)/syscall: $(SRCDIR)/syscall.c $(SRCDIR)/timeit.c
 
 $(PROGDIR)/context1: $(SRCDIR)/context1.c $(SRCDIR)/timeit.c
+
+$(PROGDIR)/context2: $(SRCDIR)/context2.c $(SRCDIR)/timeit.c
 
 $(PROGDIR)/looper: $(SRCDIR)/looper.c $(SRCDIR)/timeit.c
 

--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -142,7 +142,8 @@ SOURCES = arith.c big.c context1.c \
 	fstime.c hanoi.c \
 	pipe.c spawn.c \
 	syscall.c looper.c timeit.c time-polling.c \
-	dhry_1.c dhry_2.c dhry.h whets.c ubgears.c
+	dhry_1.c dhry_2.c dhry.h whets.c ubgears.c \
+	named_pipe.c
 TESTS = sort.src cctest.c dc.dat large.txt
 
 ifneq (,$(GRAPHIC_TESTS))
@@ -157,7 +158,8 @@ BINS = $(PROGDIR)/arithoh $(PROGDIR)/register $(PROGDIR)/short \
 	$(PROGDIR)/hanoi $(PROGDIR)/syscall $(PROGDIR)/context1 \
 	$(PROGDIR)/pipe $(PROGDIR)/spawn $(PROGDIR)/execl \
 	$(PROGDIR)/dhry2 $(PROGDIR)/dhry2reg  $(PROGDIR)/looper \
-	$(PROGDIR)/fstime $(PROGDIR)/whetstone-double $(GRAPHIC_BINS)
+	$(PROGDIR)/fstime $(PROGDIR)/whetstone-double $(PROGDIR)/named_pipe \
+	$(GRAPHIC_BINS)
 ## These compile only on some platforms...
 # $(PROGDIR)/poll $(PROGDIR)/poll2 $(PROGDIR)/select
 
@@ -265,6 +267,8 @@ $(PROGDIR)/whetstone-double: CFLAGS += -DDP -DGTODay -DUNIXBENCH
 $(PROGDIR)/whetstone-double: LDFLAGS += -lm
 
 $(PROGDIR)/pipe: $(SRCDIR)/pipe.c $(SRCDIR)/timeit.c
+
+$(PROGDIR)/named_pipe: $(SRCDIR)/named_pipe.c $(SRCDIR)/timeit.c
 
 $(PROGDIR)/execl: $(SRCDIR)/execl.c $(SRCDIR)/big.c
 

--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -125,7 +125,7 @@ my $fs = [
 
 my $oldsystem = [
     "execl", "fstime", "fsbuffer", "fsdisk", "pipe", "context1", "spawn",
-    "syscall", "named_pipe"
+    "syscall", "named_pipe", "context2"
 ];
 
 my $system = [
@@ -151,6 +151,7 @@ my $testList = {
     "pipe"          => undef,
     "named_pipe"    => undef,
     "context1"      => undef,
+    "context2"      => undef,
     "spawn"         => undef,
     "execl"         => undef,
     "fstime-w"      => undef,
@@ -252,6 +253,12 @@ my $testParams = {
         "options" => "10",
     },
     "context1" => {
+        "logmsg" => "Pipe-based Context Switching",
+        "cat"    => 'system',
+        "repeat" => 'long',
+        "options" => "10",
+    },
+    "context2" => {
         "logmsg" => "Pipe-based Context Switching",
         "cat"    => 'system',
         "repeat" => 'long',

--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -259,7 +259,7 @@ my $testParams = {
         "options" => "10",
     },
     "context2" => {
-        "logmsg" => "Pipe-based Context Switching",
+        "logmsg" => "Named Pipe-based Context Switching",
         "cat"    => 'system',
         "repeat" => 'long',
         "options" => "10",

--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -125,7 +125,7 @@ my $fs = [
 
 my $oldsystem = [
     "execl", "fstime", "fsbuffer", "fsdisk", "pipe", "context1", "spawn",
-    "syscall"
+    "syscall", "named_pipe"
 ];
 
 my $system = [
@@ -149,6 +149,7 @@ my $testList = {
     "whetstone-double"   => undef,
     "syscall"       => undef,
     "pipe"          => undef,
+    "named_pipe"    => undef,
     "context1"      => undef,
     "spawn"         => undef,
     "execl"         => undef,
@@ -258,6 +259,12 @@ my $testParams = {
     },
     "pipe" => {
         "logmsg" => "Pipe Throughput",
+        "cat"    => 'system',
+        "repeat" => 'long',
+        "options" => "10",
+    },
+    "named_pipe" => {
+        "logmsg" => "Named Pipe Throughput",
         "cat"    => 'system',
         "repeat" => 'long',
         "options" => "10",

--- a/UnixBench/src/context2.c
+++ b/UnixBench/src/context2.c
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
                     iter, check);
                 exit(2);
             }
-            if ((ret = write(fd2_write, (char *)&iter, sizeof(iter))) != sizeof(check)) {
+            if ((ret = write(fd2_write, (char *)&iter, sizeof(iter))) != sizeof(iter)) {
                 if ((ret == -1) && (errno == EPIPE)) {
                     alarm(0);
                     report(); /* does not return */

--- a/UnixBench/src/context2.c
+++ b/UnixBench/src/context2.c
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ *  The BYTE UNIX Benchmarks - Release 31 8/06/24 11:11:11
+ *          Module: context2.c   SID: 0.1 
+ *
+ *******************************************************************************
+ * Bug reports, patches, comments, suggestions should be sent to:
+ *
+ *  Ben Smith, Rick Grehan or Tom Yager
+ *  ben@bytepb.byte.com   rick_g@bytepb.byte.com   tyager@bytepb.byte.com
+ *
+ *******************************************************************************
+ *
+ ******************************************************************************/
+char SCCSid[] = "@(#) @(#)context1.c:3.3 -- 5/15/91 19:30:18";
+/*
+ *  Context switching via synchronized named pipe i/o
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <signal.h>
+#include "timeit.c"
+
+unsigned long iter;
+
+void report()
+{
+    fprintf(stderr, "COUNT|%lu|1|lps\n", iter);
+    exit(0);
+}
+
+int main(int argc, char *argv[])
+{
+    int duration;
+    unsigned long check;
+    int fd1_read, fd1_write, fd2_read, fd2_write;
+    ssize_t ret;
+    char fifo1_name[] = "/tmp/test_fifo1XXXXXX";
+    char fifo2_name[] = "/tmp/test_fifo2XXXXXX";
+
+    if (argc != 2) {
+        fprintf(stderr, "Usage: context duration\n");
+        exit(1);
+    }
+
+    duration = atoi(argv[1]);
+
+    // Generate unique FIFO names
+    if (mkstemp(fifo1_name) == -1) {
+        perror("mkstemp");
+        exit(1);
+    }
+    if (mkstemp(fifo2_name) == -1) {
+        perror("mkstemp");
+        exit(1);
+    }
+
+    // Remove the generated files and create named pipes (FIFOs) with the same names
+    unlink(fifo1_name);
+    unlink(fifo2_name);
+    if (mkfifo(fifo1_name, 0666) == -1) {
+        perror("mkfifo1");
+        exit(1);
+    }
+    if (mkfifo(fifo2_name, 0666) == -1) {
+        perror("mkfifo2");
+        exit(1);
+    }
+
+    /* set up alarm call */
+    iter = 0;
+    wake_me(duration, report);
+    signal(SIGPIPE, SIG_IGN);
+
+    if (fork()) {   /* parent process */
+        /* initiator, write to fifo1 & read from fifo2 */
+        fd1_write = open(fifo1_name, O_WRONLY);
+        fd2_read = open(fifo2_name, O_RDONLY);
+        if (fd1_write == -1 || fd2_read == -1) {
+            perror("open parent");
+            exit(1);
+        }
+
+        while (1) {
+            if ((ret = write(fd1_write, (char *)&iter, sizeof(iter))) != sizeof(iter)) {
+                if ((ret == -1) && (errno == EPIPE)) {
+                    alarm(0);
+                    report(); /* does not return */
+                }
+                if ((ret == -1) && (errno != 0) && (errno != EINTR))
+                    perror("initiator write failed");
+                exit(1);
+            }
+            if ((ret = read(fd2_read, (char *)&check, sizeof(check))) != sizeof(check)) {
+                if ((ret == 0)) { /* end-of-stream */
+                    alarm(0);
+                    report(); /* does not return */
+                }
+                if ((ret == -1) && (errno != 0) && (errno != EINTR))
+                    perror("initiator read failed");
+                exit(1);
+            }
+            if (check != iter) {
+                fprintf(stderr, "Initiator sync error: expect %lu, got %lu\n",
+                    iter, check);
+                exit(2);
+            }
+            iter++;
+        }
+    }
+    else { /* child process */
+        /* target, read from fifo1 & write to fifo2 */
+        fd1_read = open(fifo1_name, O_RDONLY);
+        fd2_write = open(fifo2_name, O_WRONLY);
+        if (fd1_read == -1 || fd2_write == -1) {
+            perror("open child");
+            exit(1);
+        }
+
+        while (1) {
+            if ((ret = read(fd1_read, (char *)&check, sizeof(check))) != sizeof(check)) {
+                if ((ret == 0)) { /* end-of-stream */
+                    alarm(0);
+                    report(); /* does not return */
+                }
+                if ((ret == -1) && (errno != 0) && (errno != EINTR))
+                    perror("target read failed");
+                exit(1);
+            }
+            if (check != iter) {
+                fprintf(stderr, "Target sync error: expect %lu, got %lu\n",
+                    iter, check);
+                exit(2);
+            }
+            if ((ret = write(fd2_write, (char *)&iter, sizeof(iter))) != sizeof(check)) {
+                if ((ret == -1) && (errno == EPIPE)) {
+                    alarm(0);
+                    report(); /* does not return */
+                }
+                if ((ret == -1) && (errno != 0) && (errno != EINTR))
+                    perror("target write failed");
+                exit(1);
+            }
+            iter++;
+        }
+    }
+
+    // Clean up
+    unlink(fifo1_name);
+    unlink(fifo2_name);
+}
+

--- a/UnixBench/src/context2.c
+++ b/UnixBench/src/context2.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
- *  The BYTE UNIX Benchmarks - Release 31 8/06/24 11:11:11
- *          Module: context2.c   SID: 0.1 
+ *  The BYTE UNIX Benchmarks - Release 3
+ *          Module: context2.c   SID: 0.1 8/06/24 11:11:11
  *
  *******************************************************************************
  * Bug reports, patches, comments, suggestions should be sent to:
@@ -11,7 +11,7 @@
  *******************************************************************************
  *
  ******************************************************************************/
-char SCCSid[] = "@(#) @(#)context1.c:3.3 -- 5/15/91 19:30:18";
+char SCCSid[] = "@(#) @(#)context2.c:0.1 -- 8/06/24 11:11:11";
 /*
  *  Context switching via synchronized named pipe i/o
  *

--- a/UnixBench/src/named_pipe.c
+++ b/UnixBench/src/named_pipe.c
@@ -1,6 +1,6 @@
 /*******************************************************************************
  *  The BYTE UNIX Benchmarks - Release 3
- *          Module: pipe.c   SID: 3.3 5/15/91 19:30:20
+ *          Module: named_pipe.c   SID: 0.1 -- 8/06/24 11:11:11
  *
  *******************************************************************************
  * Bug reports, patches, comments, suggestions should be sent to:
@@ -10,10 +10,6 @@
  *
  *******************************************************************************
  *  Modification Log:
- *  $Header: pipe.c,v 3.5 87/06/22 14:32:36 kjmcdonell Beta $
- *  August 29, 1990 - modified timing routines (ty)
- *  October 22, 1997 - code cleanup to remove ANSI C compiler warnings
- *                     Andy Kahn <kahn@zk3.dec.com>
  *
  ******************************************************************************/
 char SCCSid[] = "@(#) @(#)named_pipe.c:0.1 -- 8/06/24 11:11:11";

--- a/UnixBench/src/named_pipe.c
+++ b/UnixBench/src/named_pipe.c
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ *  The BYTE UNIX Benchmarks - Release 3
+ *          Module: pipe.c   SID: 3.3 5/15/91 19:30:20
+ *
+ *******************************************************************************
+ * Bug reports, patches, comments, suggestions should be sent to:
+ *
+ *    Ben Smith, Rick Grehan or Tom Yager
+ *    ben@bytepb.byte.com   rick_g@bytepb.byte.com   tyager@bytepb.byte.com
+ *
+ *******************************************************************************
+ *  Modification Log:
+ *  $Header: pipe.c,v 3.5 87/06/22 14:32:36 kjmcdonell Beta $
+ *  August 29, 1990 - modified timing routines (ty)
+ *  October 22, 1997 - code cleanup to remove ANSI C compiler warnings
+ *                     Andy Kahn <kahn@zk3.dec.com>
+ *
+ ******************************************************************************/
+char SCCSid[] = "@(#) @(#)named_pipe.c:0.1 -- 8/06/24 11:11:11";
+/*
+ *  named_pipe  -- test single process named pipe throughput (no context switching)
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <string.h>
+#include "timeit.c"
+
+unsigned long iter;
+
+void report()
+{
+    fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
+    exit(0);
+}
+
+int main(int argc, char *argv[])
+{
+    char buf[512];
+    int fd_read, fd_write, duration;
+    char fifo_name[] = "/tmp/test_fifoXXXXXX";
+
+    if (argc != 2) {
+        fprintf(stderr,"Usage: %s duration\n", argv[0]);
+        exit(1);
+    }
+
+    duration = atoi(argv[1]);
+
+    // Generate a unique FIFO name
+    if (mkstemp(fifo_name) == -1) {
+        perror("mkstemp");
+        exit(1);
+    }
+
+    // Remove the generated file and create a named pipe (FIFO) with the same name
+    unlink(fifo_name);
+    if (mkfifo(fifo_name, 0666) == -1) {
+        perror("mkfifo");
+        exit(1);
+    }
+
+    // Open the FIFO for reading and writing
+    fd_read = open(fifo_name, O_RDONLY | O_NONBLOCK);
+    if (fd_read == -1) {
+        perror("open for read");
+        exit(1);
+    }
+
+    fd_write = open(fifo_name, O_WRONLY | O_NONBLOCK);
+    if (fd_write == -1) {
+        perror("open for write");
+        exit(1);
+    }
+
+    wake_me(duration, report);
+    iter = 0;
+
+    while (1) {
+        if (write(fd_write, buf, sizeof(buf)) != sizeof(buf)) {
+            if ((errno != EINTR) && (errno != 0))
+                fprintf(stderr,"write failed, error %d\n", errno);
+        }
+        if (read(fd_read, buf, sizeof(buf)) != sizeof(buf)) {
+            if ((errno != EINTR) && (errno != 0))
+                fprintf(stderr,"read failed, error %d\n", errno);
+        }
+        iter++;
+    }
+
+    // Clean up
+    close(fd_read);
+    close(fd_write);
+    unlink(fifo_name);
+}
+


### PR DESCRIPTION
While debugging an performance issue, I copied the pipe.c and context.c code and added two new tests with the same behavior only using named pipes.   I hope these tests may be use for others.