### PR TITLE
Fixed Typo in Usage

### DIFF
--- a/UnixBench/USAGE
+++ b/UnixBench/USAGE
@@ -187,7 +187,7 @@ The purpose of this test is to provide a basic indicator of the performance
 of a Unix-like system; hence, multiple tests are used to test various
 aspects of the system's performance.  These test results are then compared
 to the scores from a baseline system to produce an index value, which is
-generally easier to handle than the raw sores.  The entire set of index
+generally easier to handle than the raw scores.  The entire set of index
 values is then combined to make an overall index for the system.
 
 Since 1995, the baseline system has been "George", a SPARCstation 20-61


### PR DESCRIPTION
"Sores" seems to be a typo for "Scores" in this file.