### PR TITLE
Add brief mode for cpu info display

### DIFF
--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -100,6 +100,10 @@ my $RESULTDIR = getDir('UB_RESULTDIR', $FindBin::Bin . "/results");
 # Directory where the tests are executed.
 my $TESTDIR = getDir('UB_TESTDIR', $FindBin::Bin . "/testdir");
 
+my $quietMode = 0;
+my $notQuietMode = 1;
+my $verboseMode = 2;
+my $briefMode = 3;
 
 ############################################################################
 # TEST SPECIFICATIONS
@@ -945,6 +949,7 @@ sub getNumActiveCpus {
 #    load           System load message as per "uptime".
 #    numUsers       Number of users and/or open shell sessions.
 sub getSystemInfo {
+    my ( $verbose ) = @_;
     my $info = { };
 
     # Get host system data.
@@ -979,10 +984,12 @@ sub getSystemInfo {
                                    $lang, $map, $coll;
 
     # Get details on the CPUs, if possible.
-    my $cpus = getCpuInfo();
-    if (defined($cpus)) {
-        $info->{'cpus'} = $cpus;
-        $info->{'numCpus'} = scalar(@$cpus);
+    if ($verbose != $briefMode) {
+        my $cpus = getCpuInfo();
+	if (defined($cpus)) {
+            $info->{'cpus'} = $cpus;
+            $info->{'numCpus'} = scalar(@$cpus);
+        }
     }
 
     # Get available number of CPUs (not disabled CPUs), if possible.
@@ -1066,9 +1073,11 @@ sub parseArgs {
                 die("Run: unknown test \"$word\"\n");
             }
         } elsif ($word eq "-q") {
-            $params->{'verbose'} = 0;
+            $params->{'verbose'} = $quietMode;
         } elsif ($word eq "-v") {
-            $params->{'verbose'} = 2;
+            $params->{'verbose'} = $verboseMode;
+        } elsif ($word eq "-b") {
+            $params->{'verbose'} = $briefMode;
         } elsif ($word eq "-i") {
             $params->{'iterations'} = shift(@words);
         } elsif ($word eq "-c") {
@@ -1430,7 +1439,7 @@ sub runOnePass {
 
     # Get the command to run.
     my $command = $params->{'command'};
-    if ($verbose > 1) {
+    if ($verbose == $verboseMode) {
         printf "\n";
         printf "COMMAND: \"%s\"\n", $command;
         printf "COPIES: \"%d\"\n", $copies;
@@ -1497,7 +1506,7 @@ sub runBenchmark {
     # Set up the benchmark results structure.
     my $bresult = { 'name' => $bench, 'msg' => $params->{'logmsg'} };
 
-    if ($verbose > 0) {
+    if ($verbose > $quietMode) {
         printf "\n%d x %s ", $copies, $params->{'logmsg'};
     }
 
@@ -1518,7 +1527,7 @@ sub runBenchmark {
         # make an attempt to flush buffers
         system("sync; sleep 1; sync; sleep 2");
         # display heartbeat
-        if ($verbose > 0) {
+        if ($verbose > $quietMode) {
             printf " %d", $i;
         }
 
@@ -1548,7 +1557,7 @@ sub runBenchmark {
         unlink(${TESTDIR} . "/a.out");
     }
 
-    if ($verbose > 0) {
+    if ($verbose > $quietMode) {
         printf "\n";
     }
 
@@ -1603,7 +1612,7 @@ sub runTests {
 # Display a banner indicating the configuration of the system under test
 # to the given file desc.
 sub displaySystem {
-    my ( $info, $fd ) = @_;
+    my ( $info, $fd, $verbose ) = @_;
 
     # Display basic system info.
     printf $fd "   System: %s: %s\n", $info->{'name'}, $info->{'system'};
@@ -1615,7 +1624,9 @@ sub displaySystem {
     # Get and display details on the CPUs, if possible.
     my $cpus = $info->{'cpus'};
     if (!defined($cpus)) {
-        printf $fd "   CPU: no details available\n";
+	if ($verbose != $briefMode) {
+            printf $fd "   CPU: no details available\n";
+	}
     } else {
         for (my $i = 0; $i <= $#$cpus; ++$i) {
             printf $fd "   CPU %d: %s (%.1f bogomips)\n",
@@ -1833,7 +1844,7 @@ EOF
 # Display a banner indicating the configuration of the system under test
 # to the given file desc.
 sub displaySystemHtml {
-    my ( $info, $fd ) = @_;
+    my ( $info, $fd ,$verbose) = @_;
 
     printf $fd "<h3>Test System Information</h3>\n";
     printf $fd "<p><table>\n";
@@ -1859,10 +1870,12 @@ sub displaySystemHtml {
     # Get and display details on the CPUs, if possible.
     my $cpus = $info->{'cpus'};
     if (!defined($cpus)) {
-        printf $fd "<tr>\n";
-        printf $fd "   <td><b>CPUs:</b></td>\n";
-        printf $fd "   <td colspan=2>no details available</td>\n";
-        printf $fd "</tr>\n";
+	if ($verbose != $briefMode) {
+            printf $fd "<tr>\n";
+            printf $fd "   <td><b>CPUs:</b></td>\n";
+            printf $fd "   <td colspan=2>no details available</td>\n";
+            printf $fd "</tr>\n";
+	}
     } else {
         for (my $i = 0; $i <= $#$cpus; ++$i) {
             printf $fd "<tr>\n";
@@ -2036,7 +2049,7 @@ sub main {
     my @args = @_;
 
     my $params = parseArgs(@args);
-    my $verbose = $params->{'verbose'} || 1;
+    my $verbose = $params->{'verbose'} || $notQuietMode;
     if ($params->{'iterations'}) {
         $longIterCount = $params->{'iterations'};
         $shortIterCount = int(($params->{'iterations'} + 1) / 3);
@@ -2054,7 +2067,7 @@ sub main {
     createDirrectoriesIfNotExists(@creatingDirectories);
 
     preChecks();
-    my $systemInfo = getSystemInfo();
+    my $systemInfo = getSystemInfo($verbose);
 
     # If the number of copies to run was not set, set it to 1
     # and the number of CPUs in the system (if > 1).
@@ -2070,11 +2083,11 @@ sub main {
     system("cat \"${BINDIR}/unixbench.logo\"");
 
     # Show output output directories, if not in quiet mode.
-    if ($verbose > 0) {
+    if ($verbose > $quietMode) {
         printUsingDirectories();
     }
 
-    if ($verbose > 1) {
+    if ($verbose == $verboseMode) {
         printf "\n", join(", ", @$tests);
         printf "Tests to run: %s\n", join(", ", @$tests);
     }
@@ -2106,14 +2119,14 @@ sub main {
     runHeaderHtml($systemInfo, $reportFd2);
 
     # Dump information about the system under test.
-    displaySystem($systemInfo, $reportFd);
-    displaySystemHtml($systemInfo, $reportFd2);
+    displaySystem($systemInfo, $reportFd, $verbose);
+    displaySystemHtml($systemInfo, $reportFd2, $verbose);
 
     # Run the tests!  Do a test run once for each desired number of copies;
     # for example, on a 2-CPU system, we may do a single-processing run
     # followed by a dual-processing run.
     foreach my $c (@$copies) {
-        if ($verbose > 1) {
+        if ($verbose == $verboseMode) {
             printf "Run with %s\n", number($c, "copy", "copies");
         }
         my $results = runTests($tests, $verbose, $logFile, $c);
@@ -2140,7 +2153,7 @@ sub main {
     }
 
     # Display the report, if not in quiet mode.
-    if ($verbose > 0) {
+    if ($verbose > $quietMode) {
         printf "\n";
         printf  "========================================================================\n";
         system("cat \"$reportFile\"");

--- a/UnixBench/USAGE
+++ b/UnixBench/USAGE
@@ -35,11 +35,12 @@ The Run script takes a number of options which you can use to customise a
 test, and you can specify the names of the tests to run.  The full usage
 is:
 
-    Run [ -q | -v ] [-i <n> ] [-c <n> [-c <n> ...]] [test ...]
+    Run [ -q | -b | -v ] [-i <n> ] [-c <n> [-c <n> ...]] [test ...]
 
 The option flags are:
 
   -q            Run in quiet mode.
+  -b		Run in brief mode, do not display mass of cpu info details.
   -v            Run in verbose mode.
   -i <count>    Run <count> iterations for each test -- slower tests
                 use <count> / 3, but at least 1.  Defaults to 10 (3 for


### PR DESCRIPTION
As the number of CPUs increases, the information displayed on the console may exceed one screen.
In addition, most CPU information is consistent and redundant. Therefore, the -b parameter is added
to simplify the display of CPU information.
Besides, define numbers representing test modes as more readable variables.