### PR TITLE
Fix errors: passing argument 2 of ‘signal’ from incompatible pointer …

### DIFF
--- a/UnixBench/src/arith.c
+++ b/UnixBench/src/arith.c
@@ -38,7 +38,7 @@ int dumb_stuff(int);
 volatile unsigned long iter;
 
 /* this function is called when the alarm expires */
-void report()
+void report(int sig)
 {
 	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
 	exit(0);

--- a/UnixBench/src/big.c
+++ b/UnixBench/src/big.c
@@ -47,8 +47,8 @@
 
 void	wrapup(const char *);
 void	onalarm(int);
-void	pipeerr();
-void	grunt();
+void	pipeerr(int);
+void	grunt(int);
 void getwork(void);
 #if debug
 void dumpwork(void);
@@ -405,14 +405,14 @@ void onalarm(int foo)
     alarm(GRANULE);
 }
 
-void grunt()
+void grunt(int sig)
 {
     /* timeout after label "bepatient" in main */
     exit_status = 4;
     wrapup("Timed out waiting for jobs to finish ...");
 }
 
-void pipeerr()
+void pipeerr(int sig)
 {
 	sigpipe++;
 }

--- a/UnixBench/src/context1.c
+++ b/UnixBench/src/context1.c
@@ -31,7 +31,7 @@ char SCCSid[] = "@(#) @(#)context1.c:3.3 -- 5/15/91 19:30:18";
 
 unsigned long iter;
 
-void report()
+void report(int sig)
 {
 	fprintf(stderr, "COUNT|%lu|1|lps\n", iter);
 	exit(0);
@@ -70,7 +70,7 @@ char	*argv[];
 			if ((ret = write(p1[1], (char *)&iter, sizeof(iter))) != sizeof(iter)) {
 				if ((ret == -1) && (errno == EPIPE)) {
 					alarm(0);
-					report(); /* does not return */
+					report(0); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
 					perror("master write failed");
@@ -79,7 +79,7 @@ char	*argv[];
 			if ((ret = read(p2[0], (char *)&check, sizeof(check))) != sizeof(check)) {
 				if ((ret == 0)) { /* end-of-stream */
 					alarm(0);
-					report(); /* does not return */
+					report(0); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
 					perror("master read failed");
@@ -100,7 +100,7 @@ char	*argv[];
 			if ((ret = read(p1[0], (char *)&check, sizeof(check))) != sizeof(check)) {
 				if ((ret == 0)) { /* end-of-stream */
 					alarm(0);
-					report(); /* does not return */
+					report(0); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
 					perror("slave read failed");
@@ -114,7 +114,7 @@ char	*argv[];
 			if ((ret = write(p2[1], (char *)&iter, sizeof(iter))) != sizeof(check)) {
 				if ((ret == -1) && (errno == EPIPE)) {
 					alarm(0);
-					report(); /* does not return */
+					report(0); /* does not return */
 				}
 				if ((ret == -1) && (errno != 0) && (errno != EINTR))
 					perror("slave write failed");

--- a/UnixBench/src/dhry_1.c
+++ b/UnixBench/src/dhry_1.c
@@ -42,7 +42,7 @@ char SCCSid[] = "@(#) @(#)dhry_1.c:3.4 -- 5/15/91 19:30:21";
 
 unsigned long Run_Index;
 
-void report()
+void report(int sig)
 {
 	fprintf(stderr,"COUNT|%ld|1|lps\n", Run_Index);
 	exit(0);
@@ -59,7 +59,7 @@ char            Ch_1_Glob,
 int             Arr_1_Glob [50];
 int             Arr_2_Glob [50] [50];
 
-Enumeration     Func_1 ();
+Enumeration     Func_1 (char, char);
   /* forward declaration necessary since Enumeration may not simply be int */
 
 #ifndef REG

--- a/UnixBench/src/execl.c
+++ b/UnixBench/src/execl.c
@@ -36,7 +36,7 @@ char	bss[8*1024];	/* something worthwhile */
 #undef main
 
 /* added by BYTE */
-char *getenv();
+char *getenv(const char *name);
 
 
 int main(argc, argv)	/* the real program */

--- a/UnixBench/src/fstime.c
+++ b/UnixBench/src/fstime.c
@@ -91,8 +91,8 @@ char buf[MAX_BUFSIZE];
 int                     f;
 int                     g;
 int                     i;
-void                    stop_count();
-void                    clean_up();
+void                    stop_count(int);
+void                    clean_up(int);
 int                     sigalarm = 0;
 
 /******************** MAIN ****************************/
@@ -199,7 +199,7 @@ char    *argv[];
     for (i=0; i < bufsize; ++i)
             buf[i] = i & 0xff;
 
-    signal(SIGKILL,clean_up);
+    signal(SIGKILL, clean_up);
 
     /*
      * Run the selected test.
@@ -239,11 +239,11 @@ char    *argv[];
         exit(6);
     }
     if (status) {
-        clean_up();
+        clean_up(0);
         exit(1);
     }
 
-    clean_up();
+    clean_up(0);
     exit(0);
 }
 
@@ -288,7 +288,7 @@ int w_test(int timeSecs)
                                         perror("fstime: write");
                                         return(-1);
                                 }
-                                stop_count();
+                                stop_count(0);
                                 counted += ((tmp+HALFCOUNT)/COUNTSIZE);
                         } else
                                 counted += count_per_buf;
@@ -348,7 +348,7 @@ int r_test(int timeSecs)
                                 counted += (tmp+HALFCOUNT)/COUNTSIZE;
                                 continue;
                         case EINTR:
-                                stop_count();
+                                stop_count(0);
                                 counted += (tmp+HALFCOUNT)/COUNTSIZE;
                                 break;
                         default:
@@ -415,7 +415,7 @@ int c_test(int timeSecs)
                                 counted += ( (tmp * write_score) /
                                         (read_score + write_score)
                                         + HALFCOUNT) / COUNTSIZE;
-                                stop_count();
+                                stop_count(0);
                                 break;
                         default:
                                 perror("fstime: copy read");
@@ -436,7 +436,7 @@ int c_test(int timeSecs)
                                         ( ((bufsize - tmp) * write_score) /
                                         (read_score + write_score) )
                                         + HALFCOUNT) / COUNTSIZE;
-                                stop_count();
+                                stop_count(0);
                         } else
                                 counted += count_per_buf;
                 }
@@ -457,13 +457,13 @@ int c_test(int timeSecs)
         return(0);
 }
 
-void stop_count(void)
+void stop_count(int sig)
 {
         extern int sigalarm;
         sigalarm = 1;
 }
 
-void clean_up(void)
+void clean_up(int sig)
 {
         unlink(FNAME0);
         unlink(FNAME1);

--- a/UnixBench/src/hanoi.c
+++ b/UnixBench/src/hanoi.c
@@ -30,7 +30,7 @@ unsigned long iter = 0;
 int num[4];
 long cnt;
 
-void report()
+void report(int sig)
 {
 	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
 	exit(0);

--- a/UnixBench/src/looper.c
+++ b/UnixBench/src/looper.c
@@ -31,7 +31,7 @@ unsigned long iter;
 char *cmd_argv[28];
 int  cmd_argc;
 
-void report(void)
+void report(int sig)
 {
         fprintf(stderr,"COUNT|%lu|60|lpm\n", iter);
 	exit(0);

--- a/UnixBench/src/pipe.c
+++ b/UnixBench/src/pipe.c
@@ -29,7 +29,7 @@ char SCCSid[] = "@(#) @(#)pipe.c:3.3 -- 5/15/91 19:30:20";
 
 unsigned long iter;
 
-void report()
+void report(int sig)
 {
 	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
 	exit(0);

--- a/UnixBench/src/spawn.c
+++ b/UnixBench/src/spawn.c
@@ -29,7 +29,7 @@ char SCCSid[] = "@(#) @(#)spawn.c:3.3 -- 5/15/91 19:30:20";
 
 unsigned long iter;
 
-void report()
+void report(int sig)
 {
 	fprintf(stderr,"COUNT|%lu|1|lps\n", iter);
 	exit(0);

--- a/UnixBench/src/syscall.c
+++ b/UnixBench/src/syscall.c
@@ -34,7 +34,7 @@ char SCCSid[] = "@(#) @(#)syscall.c:3.3 -- 5/15/91 19:30:21";
 
 unsigned long iter;
 
-void report()
+void report(int sig)
 {
 	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
 	exit(0);

--- a/UnixBench/src/timeit.c
+++ b/UnixBench/src/timeit.c
@@ -31,7 +31,7 @@
 
 void wake_me(seconds, func)
 	int seconds;
-	void (*func)();
+	void (*func)(int);
 {
 	/* set up the signal handler */
 	signal(SIGALRM, func);


### PR DESCRIPTION
### Fix compile errors on Fedora 42

For example:

    $ ./Run -c 1 dhry2reg whetstone-double
    gcc -o pgms/arithoh -Wall -pedantic -O3 -ffast-math -march=native -mtune=native -I ./src -DTIME -Darithoh src/arith.c
    In file included from src/arith.c:34:
    src/timeit.c: In function ‘wake_me’:
    src/timeit.c:32:6: warning: old-style function definition [-Wold-style-definition]
       32 | void wake_me(seconds, func)
          |      ^~~~~~~
    src/timeit.c:37:25: error: passing argument 2 of ‘signal’ from incompatible pointer type [-Wincompatible-pointer-types]
       37 |         signal(SIGALRM, func);
          |                         ^~~~
          |                         |
          |                         void (*)(void)
    In file included from src/timeit.c:29:
    /usr/include/signal.h:88:57: note: expected ‘__sighandler_t’ {aka ‘void (*)(int)’} but argument is of type ‘void (*)(void)’
       88 | extern __sighandler_t signal (int __sig, __sighandler_t __handler)
          |                                          ~~~~~~~~~~~~~~~^~~~~~~~~
    /usr/include/signal.h:72:16: note: ‘__sighandler_t’ declared here
       72 | typedef void (*__sighandler_t) (int);
          |                ^~~~~~~~~~~~~~