### PR TITLE
Update CFLAGS to use gnu89 standard

### DIFF
--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -119,7 +119,7 @@ endif
 
 
 ## generic gcc CFLAGS.  -DTIME must be included.
-CFLAGS += -Wall -pedantic $(OPTON) -I $(SRCDIR) -DTIME
+CFLAGS += -std=gnu89 -Wall -pedantic $(OPTON) -I $(SRCDIR) -DTIME
 
 
 ##############################################################################


### PR DESCRIPTION
Fix GCC-15 compile error, such as:
src/timeit.c:37:25: error: passing argument 2 of ‘signal’ from incompatible pointer type