### PR TITLE
Cmake add and updated source for cross compiler

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+*.a binary
+*.bmp binary
+*.db binary
+*.exe binary
+*.gif binary
+*.ico binary
+*.jar binary
+*.jks binary
+*.jpg binary
+*.lib binary
+*.o binary
+*.oobj binary
+*.png binary
+*.rtf binary
+*.so binary
+*.wav binary
+*.zip binary
+*.dat binary
+*.gz binary
+*.tar binary
+*.sh text eol=lf
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,51 @@
 UnixBench/pgms
 UnixBench/results
 UnixBench/tmp
+
+CmakeCache.txt
+*.cmake
+*.vcxproj
+*.vcxproj.filters
+*.sln
+CMakeFiles/
+_deps/
+build/
+*~
+*.sublime-project
+*.sublime-workspace
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+
+# Visual Studio 2015/2017 cache/options directory
+.vs/
+
+# IntelliJ IDE project directory
+.idea/
+
+# Visual C++ cache files
+ipch/
+*.aps
+*.ncb
+*.opendb
+*.opensdf
+*.sdf
+*.cachefile
+*.VC.db
+*.VC.VC.opendb

--- a/UnixBench/CmakeLists.txt
+++ b/UnixBench/CmakeLists.txt
@@ -1,0 +1,147 @@
+
+cmake_minimum_required(VERSION 3.16)
+project(unixbench C)
+
+# -------- Options / Configuration --------
+option(BUILD_GRAPHIC_TESTS "Build OpenGL/X11 graphics test (ubgears)" OFF)
+option(UB_NATIVE_TUNING "Enable native CPU tuning flags similar to the Makefile" OFF)
+
+# Default tick rate for Dhrystone (override with -DHZ=...)
+set(HZ "100" CACHE STRING "Timer ticks per second for Dhrystone")
+
+# Source tree layout
+set(SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+# Place all executables under build/pgms (similar to PROGDIR = ./pgms)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/pgms")
+
+# C standard
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+# Common warnings and optimization (mirrors: -Wall -pedantic -O3 -ffast-math)
+add_compile_options(-Wall -pedantic -O3 -ffast-math)
+
+# -DTIME must be defined globally (per Makefile)
+add_compile_definitions(TIME)
+
+# Add include directory (mirrors: -I $(SRCDIR))
+include_directories("${SRCDIR}")
+
+# -------- OS / CPU-specific tuning (mirrors Makefile uname logic) --------
+if(UB_NATIVE_TUNING)
+  if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|ppc64le")
+      add_compile_options(-mcpu=native -mtune=native)
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
+      # Mirrors: -march=rv64g -mabi=lp64d
+      add_compile_options(-march=rv64g -mabi=lp64d)
+    else()
+      add_compile_options(-march=native -mtune=native)
+    endif()
+  elseif(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "ppc64|ppc64le")
+      add_compile_options(-mcpu=native)
+    else()
+      # Requires compatible SDK; mirror Makefile behavior
+      add_compile_options(-march=native -mmacosx-version-min=10.10)
+    endif()
+    # As in Makefile comment for XCode/OS X assemblers
+    add_compile_options(-Wa,-q)
+  endif()
+endif()
+
+# -------- Helper: link m on UNIX-like systems --------
+if(UNIX AND NOT APPLE)
+  set(M_LIB m)
+elseif(APPLE)
+  # libm is part of libSystem on macOS; keep empty (linker handles it).
+  set(M_LIB "")
+endif()
+
+# -------- Executable Targets (mirroring Makefile) --------
+
+# arith.c variants
+add_executable(arithoh       ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(arithoh       PRIVATE arithoh)
+
+add_executable(register      ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(register      PRIVATE datum="register int")
+
+add_executable(short         ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(short         PRIVATE datum=short)
+
+add_executable(int           ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(int           PRIVATE datum=int)
+
+add_executable(long          ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(long          PRIVATE datum=long)
+
+add_executable(float         ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(float         PRIVATE datum=float)
+
+add_executable(double        ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+target_compile_definitions(double        PRIVATE datum=double)
+
+# polling variants are platform-specific in the Makefile; left disabled by default.
+# To enable, uncomment and add the desired macros.
+# add_executable(poll   ${SRCDIR}/time-polling.c)
+# target_compile_definitions(poll PRIVATE UNIXBENCH HAS_POLL)
+# add_executable(poll2  ${SRCDIR}/time-polling.c)
+# target_compile_definitions(poll2 PRIVATE UNIXBENCH HAS_POLL2)
+# add_executable(select ${SRCDIR}/time-polling.c)
+# target_compile_definitions(select PRIVATE UNIXBENCH HAS_SELECT)
+
+# Whetstone (double)
+add_executable(whetstone-double ${SRCDIR}/whets.c)
+target_compile_definitions(whetstone-double PRIVATE DP GTODay UNIXBENCH)
+target_link_libraries(whetstone-double PRIVATE ${M_LIB})
+
+# Other simple targets
+add_executable(pipe     ${SRCDIR}/pipe.c     ${SRCDIR}/timeit.c)
+#add_executable(execl    ${SRCDIR}/execl.c    ${SRCDIR}/big.c)
+add_executable(spawn    ${SRCDIR}/spawn.c    ${SRCDIR}/timeit.c)
+add_executable(hanoi    ${SRCDIR}/hanoi.c    ${SRCDIR}/timeit.c)
+add_executable(fstime   ${SRCDIR}/fstime.c)
+add_executable(syscall  ${SRCDIR}/syscall.c  ${SRCDIR}/timeit.c)
+add_executable(context1 ${SRCDIR}/context1.c ${SRCDIR}/timeit.c)
+add_executable(looper   ${SRCDIR}/looper.c   ${SRCDIR}/timeit.c)
+
+# ubgears (OpenGL/X11) — only if requested
+if(BUILD_GRAPHIC_TESTS)
+  find_package(OpenGL REQUIRED)
+  # X11: ask for core + Xext to match -lX11 -lXext
+  find_package(X11 REQUIRED)
+  if(NOT X11_Xext_FOUND AND DEFINED X11_Xext_LIB)
+    # Some CMake versions don't populate a 'FOUND' var for Xext; we’ll still use the lib var.
+    set(X11_Xext_FOUND TRUE)
+  endif()
+
+  add_executable(ubgears ${SRCDIR}/ubgears.c)
+  # Link order consistent with GL + X11 + math
+  if(X11_Xext_FOUND AND X11_Xext_LIB)
+    target_link_libraries(ubgears PRIVATE ${M_LIB} OpenGL::GL ${X11_X11_LIB} ${X11_Xext_LIB})
+  else()
+    target_link_libraries(ubgears PRIVATE ${M_LIB} OpenGL::GL ${X11_X11_LIB})
+  endif()
+endif()
+
+# Dhrystone (special compile defs, only dhry_1.c and dhry_2.c are compiled)
+add_executable(dhry2    ${SRCDIR}/dhry_1.c ${SRCDIR}/dhry_2.c ${SRCDIR}/timeit.c)
+target_compile_definitions(dhry2 PRIVATE HZ=${HZ})
+
+add_executable(dhry2reg ${SRCDIR}/dhry_1.c ${SRCDIR}/dhry_2.c ${SRCDIR}/timeit.c)
+target_compile_definitions(dhry2reg PRIVATE HZ=${HZ} REG=register)
+
+# -------- Convenience: group the typical benchmark targets --------
+set(UB_PROGRAMS
+  arithoh register short int long float double
+  hanoi syscall context1 pipe spawn execl
+  dhry2 dhry2reg looper fstime whetstone-double
+)
+
+if(BUILD_GRAPHIC_TESTS)
+  list(APPEND UB_PROGRAMS ubgears)
+endif()
+
+add_custom_target(programs DEPENDS ${UB_PROGRAMS})

--- a/UnixBench/CmakeLists.txt
+++ b/UnixBench/CmakeLists.txt
@@ -65,7 +65,7 @@ endif()
 add_executable(arithoh       ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
 target_compile_definitions(arithoh       PRIVATE arithoh)
 
-set(DATA_TYPES "char" "short" "int" "long" "double" "float")
+set(DATA_TYPES "char" "short" "int" "long" "double" "float" "register")
 
 foreach(T IN LISTS DATA_TYPES)
     # 1. Create a unique target name for each type

--- a/UnixBench/CmakeLists.txt
+++ b/UnixBench/CmakeLists.txt
@@ -65,23 +65,36 @@ endif()
 add_executable(arithoh       ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
 target_compile_definitions(arithoh       PRIVATE arithoh)
 
-add_executable(register      ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
-target_compile_definitions(register      PRIVATE datum="register int")
+set(DATA_TYPES "char" "short" "int" "long" "double" "float")
 
-add_executable(short         ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
-target_compile_definitions(short         PRIVATE datum=short)
+foreach(T IN LISTS DATA_TYPES)
+    # 1. Create a unique target name for each type
+    set(EXE_NAME "app_${T}")
 
-add_executable(int           ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
-target_compile_definitions(int           PRIVATE datum=int)
+    add_executable(${EXE_NAME} ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+    target_compile_definitions(${EXE_NAME} PRIVATE MY_TYPE=${T})
+    
+    # Optional: Set the final output name to something specific
+    # set_target_properties(${EXE_NAME} PROPERTIES OUTPUT_NAME "program_${T}")
+endforeach()
 
-add_executable(long          ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
-target_compile_definitions(long          PRIVATE datum=long)
+#add_executable(register      ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+#target_compile_definitions(register      PRIVATE MY_TYPE="register int")
 
-add_executable(float         ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
-target_compile_definitions(float         PRIVATE datum=float)
+#add_executable(short         ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+#target_compile_definitions(short         PRIVATE datum=short)
 
-add_executable(double        ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
-target_compile_definitions(double        PRIVATE datum=double)
+#add_executable(int           ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+#target_compile_definitions(int           PRIVATE datum=int)
+
+#add_executable(long          ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+#target_compile_definitions(long          PRIVATE datum=long)
+
+#add_executable(float         ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+#target_compile_definitions(float         PRIVATE datum=float)
+
+#add_executable(double        ${SRCDIR}/arith.c ${SRCDIR}/timeit.c)
+#target_compile_definitions(double        PRIVATE datum=double)
 
 # polling variants are platform-specific in the Makefile; left disabled by default.
 # To enable, uncomment and add the desired macros.

--- a/UnixBench/src/arith.c
+++ b/UnixBench/src/arith.c
@@ -85,8 +85,9 @@ int dumb_stuff(i)
 int i;
 {
 #ifndef arithoh
-	datum	x, y, z;
-		z = 0;
+	MY_TYPE x = 0;
+	MY_TYPE y = 0;
+	MY_TYPE z = 0;
 #endif
 		/*
 		 *     101

--- a/UnixBench/src/arith.c
+++ b/UnixBench/src/arith.c
@@ -31,7 +31,7 @@ char SCCSid[] = "@(#) @(#)arith.c:3.3 -- 5/15/91 19:30:19";
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "timeit.c"
+#include "timeit.h"
 
 int dumb_stuff(int);
 

--- a/UnixBench/src/big.c
+++ b/UnixBench/src/big.c
@@ -47,8 +47,8 @@
 
 void	wrapup(const char *);
 void	onalarm(int);
-void	pipeerr();
-void	grunt();
+void	pipeerr(void);
+void	grunt(void);
 void getwork(void);
 #if debug
 void dumpwork(void);
@@ -405,14 +405,14 @@ void onalarm(int foo)
     alarm(GRANULE);
 }
 
-void grunt()
+void grunt(void)
 {
     /* timeout after label "bepatient" in main */
     exit_status = 4;
     wrapup("Timed out waiting for jobs to finish ...");
 }
 
-void pipeerr()
+void pipeerr(void)
 {
 	sigpipe++;
 }

--- a/UnixBench/src/context1.c
+++ b/UnixBench/src/context1.c
@@ -27,7 +27,7 @@ char SCCSid[] = "@(#) @(#)context1.c:3.3 -- 5/15/91 19:30:18";
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include "timeit.c"
+#include "timeit.h"
 
 unsigned long iter;
 

--- a/UnixBench/src/context1.c
+++ b/UnixBench/src/context1.c
@@ -27,6 +27,7 @@ char SCCSid[] = "@(#) @(#)context1.c:3.3 -- 5/15/91 19:30:18";
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
+#include <signal.h>
 #include "timeit.h"
 
 unsigned long iter;

--- a/UnixBench/src/dhry_1.c
+++ b/UnixBench/src/dhry_1.c
@@ -37,8 +37,8 @@ char SCCSid[] = "@(#) @(#)dhry_1.c:3.4 -- 5/15/91 19:30:21";
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "timeit.h"
 #include "dhry.h"
-#include "timeit.c"
 
 unsigned long Run_Index;
 

--- a/UnixBench/src/dhry_2.c
+++ b/UnixBench/src/dhry_2.c
@@ -32,6 +32,7 @@
 /* SCCSid is defined in dhry_1.c */
 
 #include <string.h>
+#include "timeit.h"
 #include "dhry.h"
 
 #ifndef REG

--- a/UnixBench/src/dummy.c
+++ b/UnixBench/src/dummy.c
@@ -38,8 +38,8 @@ int	nusers;		/* number of concurrent users to be simulated by
 			 * this process */
 int	firstuser;	/* ordinal identification of first user for this
 			 * process */
-int	nwork = 0;	/* number of job streams */
-int	exit_status = 0;	/* returned to parent */
+int	nwork_dummy = 0;	/* number of job streams */
+int	exit_status_dummy = 0;	/* returned to parent */
 int	sigpipe;	/* pipe write error flag */
 
 struct st_work {
@@ -77,10 +77,10 @@ char	*argv[];
     int		nch;		/* # characters to write */
     int		written;	/* # characters actully written */
     char	logname[15];	/* name of the log file(s) */
-    void		onalarm(void);
-    void		pipeerr(void);
-    void		wrapup(void);
-    void		grunt(void);
+    void		onalarm_dummy(void);
+    void		pipeerr_dummy(void);
+    void		wrapup_dummy(void);
+    void		grunt_dummy(void);
     char	*malloc();
     int		pvec[2];	/* for pipes */
     char	*p;
@@ -131,7 +131,7 @@ char	*argv[];
     argv++;
 
     /* build job streams */
-    getwork();
+    getwork_dummy();
 #if debug
     dumpwork();
 #endif
@@ -150,7 +150,7 @@ char	*argv[];
 	    nchild = nusers - MAXCHILD;
 	if ((l = fork()) == -1) {
 	    /* fork failed */
-	    fatal("** clone fork failed **\n");
+	    fatal_dummy("** clone fork failed **\n");
 	    goto bepatient;
 	} else if (l > 0) {
 	    fprintf(stderr, "master clone pid %d\n", l);
@@ -189,8 +189,8 @@ char	*argv[];
     }
     est_rate = thres;
 
-    signal(SIGALRM, onalarm);
-    signal(SIGPIPE, pipeerr);
+    signal(SIGALRM, onalarm_dummy);
+    signal(SIGPIPE, pipeerr_dummy);
     alarm(GRANULE);
     while (done < nusers) {
 	for (i = 0; i < nusers; i++) {
@@ -268,31 +268,31 @@ bepatient:
 
 }
 
-onalarm()
+onalarm_dummy()
 {
     thres += est_rate;
-    signal(SIGALRM, onalarm);
+    signal(SIGALRM, onalarm_dummy);
     alarm(GRANULE);
 }
 
-grunt()
+grunt_dummy()
 {
     /* timeout after label "bepatient" in main */
-    exit_status = 4;
-    wrapup();
+    exit_status_dummy = 4;
+    wrapup_dummy();
 }
 
-pipeerr()
+pipeerr_dummy()
 {
 	sigpipe++;
 }
 
-wrapup()
+wrapup_dummy()
 {
     /* DUMMY, real code dropped */
 }
 
-getwork()
+getwork_dummy()
 {
 
     /* DUMMY, real code dropped */
@@ -302,7 +302,7 @@ getwork()
     open(); close();
 }
 
-fatal(s)
+fatal_dummy(s)
 char *s;
 {
     int	i;
@@ -314,6 +314,6 @@ char *s;
 	    fprintf(stderr, "pid %d killed off\n", child[i].pid);
     }
     fflush(stderr);
-    exit_status = 4;
+    exit_status_dummy = 4;
     return;
 }

--- a/UnixBench/src/hanoi.c
+++ b/UnixBench/src/hanoi.c
@@ -22,7 +22,7 @@ char SCCSid[] = "@(#) @(#)hanoi.c:3.3 -- 5/15/91 19:30:20";
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "timeit.c"
+#include "timeit.h"
 
 void mov(int n, int f, int t);
 

--- a/UnixBench/src/looper.c
+++ b/UnixBench/src/looper.c
@@ -25,7 +25,7 @@ char SCCSid[] = "@(#) @(#)looper.c:1.4 -- 5/15/91 19:30:22";
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/wait.h>
-#include "timeit.c"
+#include "timeit.h"
 
 unsigned long iter;
 char *cmd_argv[28];

--- a/UnixBench/src/pipe.c
+++ b/UnixBench/src/pipe.c
@@ -25,7 +25,7 @@ char SCCSid[] = "@(#) @(#)pipe.c:3.3 -- 5/15/91 19:30:20";
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
-#include "timeit.c"
+#include "timeit.h"
 
 unsigned long iter;
 

--- a/UnixBench/src/spawn.c
+++ b/UnixBench/src/spawn.c
@@ -25,7 +25,7 @@ char SCCSid[] = "@(#) @(#)spawn.c:3.3 -- 5/15/91 19:30:20";
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/wait.h>
-#include "timeit.c"
+#include "timeit.h"
 
 unsigned long iter;
 

--- a/UnixBench/src/syscall.c
+++ b/UnixBench/src/syscall.c
@@ -30,7 +30,7 @@ char SCCSid[] = "@(#) @(#)syscall.c:3.3 -- 5/15/91 19:30:21";
 #include <sys/wait.h>
 #include <sys/syscall.h>
 #include <unistd.h>
-#include "timeit.c"
+#include "timeit.h"
 
 unsigned long iter;
 

--- a/UnixBench/src/timeit.h
+++ b/UnixBench/src/timeit.h
@@ -1,7 +1,7 @@
 /*******************************************************************************
  *          
  *  The BYTE UNIX Benchmarks - Release 3
- *          Module: timeit.c   SID: 3.3 5/15/91 19:30:21
+ *          Module: timeit.h   SID: 3.3 5/15/91 19:30:21
  *******************************************************************************
  * Bug reports, patches, comments, suggestions should be sent to:
  *
@@ -21,20 +21,8 @@
 
 /* this module is #included in other modules--no separate SCCS ID */
 
-/*
- *  Timing routine
- *
- */
-
-#include <signal.h>
-#include <unistd.h>
-#include "timeit.h"
-
-void wake_me(int seconds, void (*func)(int))
-{
-	/* set up the signal handler */
-	signal(SIGALRM, func);
-	/* get the clock running */
-	alarm(seconds);
-}
+#ifndef __TIMEIT_H__
+#define __TIMEIT_H__
+void wake_me(int, void (*func)(int));
+#endif
 


### PR DESCRIPTION
Using Cmake as cross compilers support Cmake generation of make files.  But also had to update source code for some include files.  Don't think these changes will break older compilers, but need to verify.  
CMake added for easy of generating make files for different systems.  "register int" is not available on ARM7 cross compiler.