### PR TITLE
Prevent dhry `Run_Index` from being optimized away by LTO

### DIFF
--- a/UnixBench/src/dhry_1.c
+++ b/UnixBench/src/dhry_1.c
@@ -40,7 +40,7 @@ char SCCSid[] = "@(#) @(#)dhry_1.c:3.4 -- 5/15/91 19:30:21";
 #include "dhry.h"
 #include "timeit.c"
 
-unsigned long Run_Index;
+volatile unsigned long Run_Index;
 
 void report()
 {


### PR DESCRIPTION
By qualifying `Run_Index` as volatile, LTO will no longer optimize away accumulation and writeouts to the static storage.

This patch may lower the performance score on working normal (non-LTO) runs.

**After**:

```console
$ ./UnixBench/pgms/dhry2reg 3
COUNT|990391073|1|lps
$ ./UnixBench/pgms/dhry2 3
COUNT|989672562|1|lps
```

Resolves #121.