### PR TITLE
Switch to -std=gnu89 and suppress C90 mixed declaration warnings

### DIFF
--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -119,7 +119,7 @@ endif
 
 
 ## generic gcc CFLAGS.  -DTIME must be included.
-CFLAGS += -Wall -pedantic $(OPTON) -I $(SRCDIR) -DTIME
+CFLAGS += -Wall -pedantic $(OPTON) -I $(SRCDIR) -DTIME -std=gnu89 -Wno-declaration-after-statement
 
 
 ##############################################################################


### PR DESCRIPTION
Fix Issue #123 