### PR TITLE
Fix printf format mismatch for unsigned long variables

### DIFF
--- a/UnixBench/src/arith.c
+++ b/UnixBench/src/arith.c
@@ -40,7 +40,7 @@ volatile unsigned long iter;
 /* this function is called when the alarm expires */
 void report()
 {
-	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
+	fprintf(stderr,"COUNT|%lu|1|lps\n", iter);
 	exit(0);
 }
 

--- a/UnixBench/src/dhry_1.c
+++ b/UnixBench/src/dhry_1.c
@@ -44,7 +44,7 @@ volatile unsigned long Run_Index;
 
 void report()
 {
-	fprintf(stderr,"COUNT|%ld|1|lps\n", Run_Index);
+	fprintf(stderr,"COUNT|%lu|1|lps\n", Run_Index);
 	exit(0);
 }
 

--- a/UnixBench/src/hanoi.c
+++ b/UnixBench/src/hanoi.c
@@ -32,7 +32,7 @@ long cnt;
 
 void report()
 {
-	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
+	fprintf(stderr,"COUNT|%lu|1|lps\n", iter);
 	exit(0);
 }
 

--- a/UnixBench/src/pipe.c
+++ b/UnixBench/src/pipe.c
@@ -31,7 +31,7 @@ unsigned long iter;
 
 void report()
 {
-	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
+	fprintf(stderr,"COUNT|%lu|1|lps\n", iter);
 	exit(0);
 }
 

--- a/UnixBench/src/syscall.c
+++ b/UnixBench/src/syscall.c
@@ -36,7 +36,7 @@ unsigned long iter;
 
 void report()
 {
-	fprintf(stderr,"COUNT|%ld|1|lps\n", iter);
+	fprintf(stderr,"COUNT|%lu|1|lps\n", iter);
 	exit(0);
 }
 


### PR DESCRIPTION
Use %lu instead of %ld for unsigned long iteration counters in report() functions. Using %ld for unsigned long is undefined behavior per the C standard.

Affected files: arith.c, dhry_1.c, hanoi.c, pipe.c, syscall.c