### PR TITLE
Add volatile to prevent global loop counters from being optimized away

### DIFF
--- a/UnixBench/src/context1.c
+++ b/UnixBench/src/context1.c
@@ -29,7 +29,7 @@ char SCCSid[] = "@(#) @(#)context1.c:3.3 -- 5/15/91 19:30:18";
 #include <errno.h>
 #include "timeit.c"
 
-unsigned long iter;
+volatile unsigned long iter;
 
 void report()
 {

--- a/UnixBench/src/hanoi.c
+++ b/UnixBench/src/hanoi.c
@@ -26,7 +26,7 @@ char SCCSid[] = "@(#) @(#)hanoi.c:3.3 -- 5/15/91 19:30:20";
 
 void mov(int n, int f, int t);
 
-unsigned long iter = 0;
+volatile unsigned long iter = 0;
 int num[4];
 long cnt;
 

--- a/UnixBench/src/looper.c
+++ b/UnixBench/src/looper.c
@@ -27,7 +27,7 @@ char SCCSid[] = "@(#) @(#)looper.c:1.4 -- 5/15/91 19:30:22";
 #include <sys/wait.h>
 #include "timeit.c"
 
-unsigned long iter;
+volatile unsigned long iter;
 char *cmd_argv[28];
 int  cmd_argc;
 

--- a/UnixBench/src/pipe.c
+++ b/UnixBench/src/pipe.c
@@ -27,7 +27,7 @@ char SCCSid[] = "@(#) @(#)pipe.c:3.3 -- 5/15/91 19:30:20";
 #include <errno.h>
 #include "timeit.c"
 
-unsigned long iter;
+volatile unsigned long iter;
 
 void report()
 {

--- a/UnixBench/src/spawn.c
+++ b/UnixBench/src/spawn.c
@@ -27,7 +27,7 @@ char SCCSid[] = "@(#) @(#)spawn.c:3.3 -- 5/15/91 19:30:20";
 #include <sys/wait.h>
 #include "timeit.c"
 
-unsigned long iter;
+volatile unsigned long iter;
 
 void report()
 {

--- a/UnixBench/src/syscall.c
+++ b/UnixBench/src/syscall.c
@@ -32,7 +32,7 @@ char SCCSid[] = "@(#) @(#)syscall.c:3.3 -- 5/15/91 19:30:21";
 #include <unistd.h>
 #include "timeit.c"
 
-unsigned long iter;
+volatile unsigned long iter;
 
 void report()
 {


### PR DESCRIPTION
The global `iter` variable is incremented in a while(1) loop and read asynchronously by a SIGALRM signal handler (report()). Without volatile, the compiler cannot know the signal handler reads it and may optimize away the loop or cache the value in a register.

Affected files: hanoi.c, syscall.c, pipe.c, context1.c, spawn.c, looper.c