### PR TITLE
unixbench release 6.0.1

### DIFF
--- a/UnixBench/Makefile
+++ b/UnixBench/Makefile
@@ -1,5 +1,5 @@
 ##############################################################################
-#	UnixBench v6.0.0
+#	UnixBench v6.0.1
 #  Based on The BYTE UNIX Benchmarks - Release 3
 #          Module: Makefile   SID: 3.9 5/15/91 19:30:15
 #

--- a/UnixBench/README
+++ b/UnixBench/README
@@ -1,4 +1,4 @@
-Version 6.0.0 -- 2025-05-21
+Version 6.0.1 -- 2026-05-19
 
 ================================================================
 To use Unixbench:
@@ -26,6 +26,21 @@ For information on adding tests into the benchmark, see "WRITING_TESTS".
 
 
 ===================== RELEASE NOTES =====================================
+
+========================  May 19 ==========================
+v6.0.1
+
+Bug Fixes
+- Fixed compilation failures on modern GCC (15+) and Clang (21+) by
+  specifying -std=gnu89 and suppressing C90 mixed declaration warnings
+  in the Makefile.
+- Added volatile qualifier to global loop counter variables (iter/Run_Index)
+  in hanoi.c, syscall.c, pipe.c, context1.c, spawn.c, looper.c, and dhry_1.c
+  to prevent LTO and aggressive optimizers from eliminating benchmark loops.
+- Fixed incorrect printf format specifiers (%ld → %lu) for unsigned long
+  variables in arith.c, dhry_1.c, hanoi.c, pipe.c, syscall.c, and fstime.c.
+  The mismatch caused undefined behavior and corrupted COUNT output on some
+  platforms.
 
 ========================  May 21 ==========================
 v6.0.0

--- a/UnixBench/Run
+++ b/UnixBench/Run
@@ -10,7 +10,7 @@ use FindBin;
 
 
 ############################################################################
-#  UnixBench - Release 6.0.0, based on:
+#  UnixBench - Release 6.0.1, based on:
 #  The BYTE UNIX Benchmarks - Release 5.1.3
 #
 ############################################################################
@@ -70,7 +70,7 @@ use FindBin;
 ############################################################################
 
 # Version number of the script.
-my $version = "6.0.0";
+my $version = "6.0.1";
 
 # The setting of LANG makes a huge difference to some of the scores,
 # particularly depending on whether UTF-8 is used.  So we always set

--- a/UnixBench/pgms/unixbench.logo
+++ b/UnixBench/pgms/unixbench.logo
@@ -6,9 +6,9 @@
    #    #  #   ##  #   #  #           #    #  #       #   ##  #    #  #    #
     ####   #    #  #  #    #          #####   ######  #    #   ####   #    #
 
-   Version 6.0.0                      Based on the Byte Magazine Unix Benchmark
+   Version 6.0.1                      Based on the Byte Magazine Unix Benchmark
 
    Multi-CPU version                  Version 5 revisions by Ian Smith,
                                       Sunnyvale, CA, USA
-   May 21, 2025                       johantheghost at yahoo period com
+   May 19, 2026                       johantheghost at yahoo period com
 


### PR DESCRIPTION
 Changes

  Build System

  - Specify C standard (Makefile): Added -std=gnu89 -Wno-declaration-after-statement to CFLAGS. Fixes compilation failures on GCC 15+ and Clang 21+ where
  implicit function declarations and K&R-style definitions are no longer accepted by default. (#125 (https://github.com/kdlucas/byte-unixbench/pull/125))

  Compiler Optimization and Link-Time Optimization (LTO) Fixes

  - Prevent loop counters from being optimized away (arith.c was already volatile): Added volatile qualifier to global benchmark iteration counters in
  dhry_1.c, hanoi.c, syscall.c, pipe.c, context1.c, spawn.c, and looper.c. These variables are incremented in tight loops and read asynchronously by SIGALRM
   signal handlers. Without volatile, LTO and aggressive optimizers (GCC 15+, Clang 21+) may eliminate the loops entirely or cache stale register values,
  producing zero or incorrect benchmark scores. (#122 (https://github.com/kdlucas/byte-unixbench/pull/122))

  Printf Format String Fixes

  - Fix %ld → %lu for unsigned long variables across 6 files (arith.c, dhry_1.c, hanoi.c, pipe.c, syscall.c, fstime.c). Using %ld (signed) for unsigned long
   arguments is undefined behavior per the C standard. On some platforms this caused garbled or negative iteration counts in COUNT| output, corrupting
  benchmark results. (#126 (https://github.com/kdlucas/byte-unixbench/pull/126), #127 (https://github.com/kdlucas/byte-unixbench/pull/127))